### PR TITLE
fix go install issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/koshqua/csv2struct
+module github.com/Koshqua/csv2struct
 
 go 1.17
 


### PR DESCRIPTION
Type causes go install not to work.

Fixes #1 